### PR TITLE
Fix animation curve parameters.

### DIFF
--- a/AutoScrollLabel.m
+++ b/AutoScrollLabel.m
@@ -101,7 +101,7 @@ static void each_object(NSArray *objects, void (^block)(id object))
 	_pauseInterval = kDefaultPauseTime;
 	_labelSpacing = kDefaultLabelBufferSpace;
     self.textAlignment = UITextAlignmentLeft;
-    self.animationOptions = UIViewAnimationCurveEaseIn;
+    self.animationOptions = UIViewAnimationOptionCurveEaseIn;
 	self.showsVerticalScrollIndicator = NO;
 	self.showsHorizontalScrollIndicator = NO;
     self.scrollEnabled = NO;


### PR DESCRIPTION
Animation curve setting wasn't propagating due to use of the
non-bit-masked version of the constant.

As a result, the behavior was EaseInEaseOut, despite being set to
EaseIn, and the code base provided a bad example of which constant to
use to set the curve externally.

See issue #13 https://github.com/cbess/AutoScrollLabel/issues/13
