### PR TITLE
remove scroll animation when resetting autoscroll label to text that doe...

### DIFF
--- a/CBAutoScrollLabel/CBAutoScrollLabel.m
+++ b/CBAutoScrollLabel/CBAutoScrollLabel.m
@@ -113,6 +113,8 @@ static void each_object(NSArray *objects, void (^block)(id object))
 - (void)setFrame:(CGRect)frame
 {
     [super setFrame:frame];
+	
+    [self refreshLabels];
     [self applyGradientMaskForFadeLength:self.fadeLength enableFade:self.scrolling];
 }
 
@@ -291,7 +293,8 @@ static void each_object(NSArray *objects, void (^block)(id object))
     
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(scrollLabelIfNeeded) object:nil];
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(enableShadow) object:nil];
-    
+    [self.scrollView.layer removeAllAnimations];
+	
     BOOL doScrollLeft = (self.scrollDirection == CBAutoScrollDirectionLeft);
     self.scrollView.contentOffset = (doScrollLeft ? CGPointZero : CGPointMake(labelWidth + self.labelSpacing, 0));
     

--- a/CBAutoScrollLabel/CBAutoScrollLabel.m
+++ b/CBAutoScrollLabel/CBAutoScrollLabel.m
@@ -365,6 +365,9 @@ static void each_object(NSArray *objects, void (^block)(id object))
         self.mainLabel.hidden = NO;
         self.mainLabel.textAlignment = self.textAlignment;
         
+        // remove scroll animation
+        [self.scrollView.layer removeAllAnimations];
+
         [self applyGradientMaskForFadeLength:0 enableFade:NO];
 	}
 }


### PR DESCRIPTION
I ran into a problem where if you're setting new text on an autoscroll label, and the old text required scrolling but the new text didn't, the new text would continue to scroll in, which would look very awkward. This change makes it so the new text appears centered right away.

This is my first github pull request, so let me know if I missed anything. Thanks for the great class!